### PR TITLE
SS-108 Return error when requesting a non-exist pass

### DIFF
--- a/backend/src/main/java/ru/hh/superscoring/dao/TestPassDao.java
+++ b/backend/src/main/java/ru/hh/superscoring/dao/TestPassDao.java
@@ -135,7 +135,7 @@ public class TestPassDao extends GenericDao {
             "inner join User u on tp.userId = u.id " +
             "where tp.id = :testPassId", UserPassDto.class)
         .setParameter("testPassId", testPassId)
-        .getSingleResult();
+        .uniqueResult();
   }
 
 }


### PR DESCRIPTION
https://trello.com/c/aO5G3why - [SS-108] Исправить сообщение об ошибке на ручке test/results/{pass_id}

При попытке получить с бэка результат прохождения по несуществующему id прохождения, выпадает: "No entity found for query"
А должно - "404 There is no such 'TestPass' in the system"